### PR TITLE
Add cache tags to TopMenu block

### DIFF
--- a/Block/Html/TopMenu.php
+++ b/Block/Html/TopMenu.php
@@ -65,6 +65,18 @@ class TopMenu extends Template
         $this->filterProvider = $filterProvider;
         parent::__construct($context, $data);
     }
+    
+    protected function getCacheTags()
+    {
+        return \array_merge(
+            parent::getCacheTags(),
+            $this->getStoreCategories()->walk(
+                function ($category) {
+                    return \Magento\Catalog\Model\Category::CACHE_TAG . '_' . $category->getId();
+                }
+            )
+        );
+    }
 
     /**
      * Retrieve current store categories


### PR DESCRIPTION
Fixes an issue where the cache is not cleared for 1 hour after adding a category to the top menu