### PR TITLE
Compatibility with magento 2.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "proprietary"
     ],
     "require": {
-        "php": "~7.0|~7.1",
+        "php": "> 7.0",
         "magento/framework": "101.0.*|^102.0.0|^103.0"
         },
     "repositories": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "proprietary"
     ],
     "require": {
-        "php": "> 7.0",
+        "php": ">7.0",
         "magento/framework": "101.0.*|^102.0.0|^103.0"
         },
     "repositories": {


### PR DESCRIPTION
Allowing for the module to be installed from PHP 8.1, if I find any issues once I install it on 8.1 I will come in and add a new version for the fix and lock that on 8.1 specifically 